### PR TITLE
Fix durationToMilliseconds to support partial duration objects

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,12 +1,14 @@
-import { format } from "./src";
+import { format, formatDuration } from "./src";
 
 const date = "2020-10-20T04:10:00Z";
 const baseDate = "2020-10-19T00:08:29Z";
 
-const result = format({
-	date,
-	baseDate,
-	format: "d 'days', s 'seconds,' h 'hours'",
-});
+// const result = format({
+// 	date,
+// 	baseDate,
+// 	format: "d 'days', s 'seconds,' h 'hours'",
+// });
+
+const result = formatDuration({ days: 3 }, "d 'days ago'");
 
 console.log("📅 \u001b[" + 32 + "m" + `${result}` + "\u001b[0m"); // eslint-disable-line

--- a/src/durationToMilliseconds/index.ts
+++ b/src/durationToMilliseconds/index.ts
@@ -5,7 +5,7 @@ export function durationToMilliseconds(duration: DurationWithIndex): number {
 	return Object.keys(durationConfig).reduce(
 		(milliseconds, durationConfigProperty) => {
 			const { key, ms } = durationConfig[durationConfigProperty];
-			return milliseconds + duration[key] * ms;
+			return duration[key] ? milliseconds + duration[key] * ms : milliseconds;
 		},
 		0
 	);


### PR DESCRIPTION
**before:**
```
formatDuration({ days: 3 }, "d 'days ago'");
//=> "NaN days ago"
```

**after:**
```
formatDuration({ days: 3 }, "d 'days ago'");
//=> "3 days ago"
```